### PR TITLE
Downgrade abseil-cpp dep in riegeli module for protobuf compat.

### DIFF
--- a/modules/riegeli/0.0.0-20240122-ac83dce/MODULE.bazel
+++ b/modules/riegeli/0.0.0-20240122-ac83dce/MODULE.bazel
@@ -19,7 +19,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "abseil-cpp",
-    version = "20240116.0",
+    version = "20230802.1",
     repo_name = "com_google_absl",
 )
 

--- a/modules/riegeli/0.0.0-20240122-ac83dce/patches/module_dot_bazel.patch
+++ b/modules/riegeli/0.0.0-20240122-ac83dce/patches/module_dot_bazel.patch
@@ -22,7 +22,7 @@
 +)
 +bazel_dep(
 +    name = "abseil-cpp",
-+    version = "20240116.0",
++    version = "20230802.1",
 +    repo_name = "com_google_absl",
 +)
 +

--- a/modules/riegeli/0.0.0-20240122-ac83dce/source.json
+++ b/modules/riegeli/0.0.0-20240122-ac83dce/source.json
@@ -4,6 +4,6 @@
     "strip_prefix": "riegeli-ac83dce9b9b632b6b3fcf55872f42b6b551cc47e",
     "patch_strip": 0,
     "patches": {
-        "module_dot_bazel.patch": "sha256-f/4zBzdEidPd9TUxuunbwEKFThASsRHo961J4MiKqyE="
+        "module_dot_bazel.patch": "sha256-2dhpAISoebmwSWvtFMSyDI+D0St0+sdsUpr99FebqiI="
     }
 }


### PR DESCRIPTION
Note that normally modifying an existing module version is not safe, but this module is not yet used.