### PR TITLE
build: Add rules_jvm_external@6.2.bzlmod.1

### DIFF
--- a/modules/rules_jvm_external/6.2.bzlmod.1/MODULE.bazel
+++ b/modules/rules_jvm_external/6.2.bzlmod.1/MODULE.bazel
@@ -1,0 +1,868 @@
+module(
+    name = "rules_jvm_external",
+    version = "6.2.bzlmod.1",
+    bazel_compatibility = [">=7.0.0"],
+)
+
+bazel_dep(
+    name = "bazel_features",
+    version = "1.13.0",
+)
+bazel_dep(
+    name = "bazel_skylib",
+    version = "1.7.1",
+)
+bazel_dep(
+    name = "platforms",
+    version = "0.0.10",
+)
+bazel_dep(
+    name = "rules_java",
+    version = "7.4.0",
+)
+bazel_dep(
+    name = "rules_kotlin",
+    version = "1.9.5",
+)
+bazel_dep(
+    name = "rules_android",
+    version = "0.1.1",
+)
+bazel_dep(
+    name = "stardoc",
+    version = "0.7.0",
+    repo_name = "io_bazel_stardoc",
+)
+
+# Remove this once rules_android has rolled out official Bzlmod support
+remote_android_extensions = use_extension("@bazel_tools//tools/android:android_extensions.bzl", "remote_android_tools_extensions")
+use_repo(remote_android_extensions, "android_gmaven_r8", "android_tools")
+
+maven = use_extension(":extensions.bzl", "maven")
+
+_MAVEN_VERSION = "3.9.8"
+
+_MAVEN_RESOLVER_VERSION = "1.9.20"
+
+# NOTE: Please keep any changes to this maven.install in sync with the
+# definition in repositories.bzl
+maven.install(
+    name = "rules_jvm_external_deps",
+    artifacts = [
+        "com.google.auth:google-auth-library-credentials:1.23.0",
+        "com.google.auth:google-auth-library-oauth2-http:1.23.0",
+        "com.google.cloud:google-cloud-core:2.40.0",
+        "com.google.cloud:google-cloud-storage:2.40.1",
+        "com.google.code.gson:gson:2.11.0",
+        "com.google.googlejavaformat:google-java-format:1.22.0",
+        "com.google.guava:guava:33.2.1-jre",
+        "org.apache.maven:maven-artifact:%s" % _MAVEN_VERSION,
+        "org.apache.maven:maven-core:%s" % _MAVEN_VERSION,
+        "org.apache.maven:maven-model:%s" % _MAVEN_VERSION,
+        "org.apache.maven:maven-model-builder:%s" % _MAVEN_VERSION,
+        "org.apache.maven:maven-settings:%s" % _MAVEN_VERSION,
+        "org.apache.maven:maven-settings-builder:%s" % _MAVEN_VERSION,
+        "org.apache.maven:maven-resolver-provider:%s" % _MAVEN_VERSION,
+        "org.apache.maven.resolver:maven-resolver-api:%s" % _MAVEN_RESOLVER_VERSION,
+        "org.apache.maven.resolver:maven-resolver-impl:%s" % _MAVEN_RESOLVER_VERSION,
+        "org.apache.maven.resolver:maven-resolver-connector-basic:%s" % _MAVEN_RESOLVER_VERSION,
+        "org.apache.maven.resolver:maven-resolver-spi:%s" % _MAVEN_RESOLVER_VERSION,
+        "org.apache.maven.resolver:maven-resolver-transport-file:%s" % _MAVEN_RESOLVER_VERSION,
+        "org.apache.maven.resolver:maven-resolver-transport-http:%s" % _MAVEN_RESOLVER_VERSION,
+        "org.apache.maven.resolver:maven-resolver-util:%s" % _MAVEN_RESOLVER_VERSION,
+        "org.codehaus.plexus:plexus-cipher:2.1.0",
+        "org.codehaus.plexus:plexus-sec-dispatcher:2.0",
+        "org.codehaus.plexus:plexus-utils:3.5.1",
+        "org.fusesource.jansi:jansi:2.4.1",
+        "org.slf4j:jul-to-slf4j:2.0.12",
+        "org.slf4j:log4j-over-slf4j:2.0.12",
+        "org.slf4j:slf4j-simple:2.0.12",
+        "software.amazon.awssdk:s3:2.26.12",
+    ],
+    fail_if_repin_required = True,
+    fetch_sources = True,
+    lock_file = "//:rules_jvm_external_deps_install.json",
+    strict_visibility = True,
+)
+use_repo(
+    maven,
+    "rules_jvm_external_deps",
+    "unpinned_rules_jvm_external_deps",
+)
+
+http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+_COURSIER_CLI_VERSION = "v2.1.8"
+
+COURSIER_CLI_HTTP_FILE_NAME = ("coursier_cli_" + _COURSIER_CLI_VERSION).replace(".", "_").replace("-", "_")
+
+COURSIER_CLI_GITHUB_ASSET_URL = "https://github.com/coursier/coursier/releases/download/{COURSIER_CLI_VERSION}/coursier.jar".format(COURSIER_CLI_VERSION = _COURSIER_CLI_VERSION)
+
+# Run 'bazel run //:mirror_coursier' to upload a copy of the jar to the Bazel mirror.
+COURSIER_CLI_BAZEL_MIRROR_URL = "https://mirror.bazel.build/coursier_cli/" + COURSIER_CLI_HTTP_FILE_NAME + ".jar"
+
+COURSIER_CLI_SHA256 = "2b78bfdd3ef13fd1f42f158de0f029d7cbb1f4f652d51773445cf2b6f7918a87"
+
+http_file(
+    name = "coursier_cli",
+    sha256 = COURSIER_CLI_SHA256,
+    urls = [COURSIER_CLI_GITHUB_ASSET_URL],
+)
+
+http_file(
+    name = "buildifier-linux-arm64",
+    sha256 = "c22a44eee37b8927167ee6ee67573303f4e31171e7ec3a8ea021a6a660040437",
+    urls = ["https://github.com/bazelbuild/buildtools/releases/download/v7.1.2/buildifier-linux-arm64"],
+)
+
+http_file(
+    name = "buildifier-linux-x86_64",
+    sha256 = "28285fe7e39ed23dc1a3a525dfcdccbc96c0034ff1d4277905d2672a71b38f13",
+    urls = ["https://github.com/bazelbuild/buildtools/releases/download/v7.1.2/buildifier-linux-amd64"],
+)
+
+http_file(
+    name = "buildifier-macos-arm64",
+    sha256 = "d0909b645496608fd6dfc67f95d9d3b01d90736d7b8c8ec41e802cb0b7ceae7c",
+    urls = ["https://github.com/bazelbuild/buildtools/releases/download/v7.1.2/buildifier-darwin-arm64"],
+)
+
+http_file(
+    name = "buildifier-macos-x86_64",
+    sha256 = "687c49c318fb655970cf716eed3c7bfc9caeea4f2931a2fd36593c458de0c537",
+    urls = ["https://github.com/bazelbuild/buildtools/releases/download/v7.1.2/buildifier-darwin-amd64"],
+)
+
+############# Dev dependencies below here
+
+bazel_dep(
+    name = "protobuf",
+    # Note: we use 27.2 in MODULE.bazel to avoid the warning:
+    #   The maven repository 'maven' is used in two different bazel modules, originally in 'rules_jvm_external' and now in 'protobuf'
+    # But we use 21.7 in WORKSPACE because protobuf 27.2 doesn't work with Bazel 5.x
+    # https://github.com/protocolbuffers/protobuf/commit/a80daa2a2caaaac9ebe9ae6bb1b639c2771c5c55
+    # This should be ok because we only use the protobuf dep to pull in the google/protobuf/wrappers.proto for testing
+    version = "27.2",
+    dev_dependency = True,
+)
+bazel_dep(
+    name = "bzlmod_lock_files",
+    version = "0.0.0",
+    dev_dependency = True,
+)
+local_path_override(
+    module_name = "bzlmod_lock_files",
+    path = "tests/integration/bzlmod_lock_files",
+)
+
+dev_maven = use_extension(
+    ":extensions.bzl",
+    "maven",
+    dev_dependency = True,
+)
+dev_maven.install(
+    artifacts = [
+        "com.google.guava:guava:31.1-jre",
+        "org.hamcrest:hamcrest-core:2.1",
+    ],
+    lock_file = "@rules_jvm_external//:maven_install.json",
+    resolver = "coursier",
+)
+dev_maven.install(
+    name = "duplicate_version_warning",
+    artifacts = [
+        "com.fasterxml.jackson.core:jackson-annotations:2.10.1",
+        "com.fasterxml.jackson.core:jackson-annotations:2.12.1",
+        "com.fasterxml.jackson.core:jackson-annotations:2.10.1",
+        "com.fasterxml.jackson.core:jackson-annotations:2.11.2",
+        "com.github.jnr:jffi:1.3.4",
+    ],
+    repositories = [
+        "https://repo1.maven.org/maven2",
+        "https://maven.google.com",
+    ],
+)
+dev_maven.artifact(
+    name = "duplicate_version_warning",
+    artifact = "jffi",
+    classifier = "native",
+    group = "com.github.jnr",
+    version = "1.3.3",
+)
+dev_maven.artifact(
+    name = "duplicate_version_warning",
+    artifact = "jffi",
+    classifier = "native",
+    group = "com.github.jnr",
+    version = "1.3.2",
+)
+dev_maven.install(
+    name = "duplicate_version_warning_same_version",
+    artifacts = [
+        "com.fasterxml.jackson.core:jackson-annotations:2.10.1",
+        "com.fasterxml.jackson.core:jackson-annotations:2.10.1",
+    ],
+    repositories = [
+        "https://repo1.maven.org/maven2",
+        "https://maven.google.com",
+    ],
+)
+dev_maven.artifact(
+    name = "duplicate_version_warning_same_version",
+    artifact = "jffi",
+    classifier = "native",
+    group = "com.github.jnr",
+    version = "1.3.3",
+)
+dev_maven.artifact(
+    name = "duplicate_version_warning_same_version",
+    artifact = "jffi",
+    classifier = "native",
+    group = "com.github.jnr",
+    version = "1.3.3",
+)
+dev_maven.artifact(
+    name = "exclusion_testing",
+    artifact = "guava",
+    exclusions = [
+        "com.google.j2objc:j2objc-annotations",
+        "org.codehaus.mojo:animal-sniffer-annotations",
+    ],
+    group = "com.google.guava",
+    version = "27.0-jre",
+)
+dev_maven.install(
+    name = "forcing_versions",
+    artifacts = [
+        # And something that depends on a more recent version of guava
+        "xyz.rogfam:littleproxy:2.1.0",
+    ],
+)
+
+# Specify an ancient version of guava, and force its use. If we try to use `[23.3-jre]` as the version,
+# the resolution will fail when using `coursier`
+dev_maven.artifact(
+    name = "forcing_versions",
+    artifact = "guava",
+    force_version = True,
+    group = "com.google.guava",
+    version = "23.3-jre",
+)
+dev_maven.install(
+    name = "global_exclusion_testing",
+    artifacts = [
+        "com.google.guava:guava:27.0-jre",  # depends on animal-sniffer-annotations and j2objc-annotations
+        "com.squareup.okhttp3:okhttp:3.14.1",  # depends on animal-sniffer-annotations
+        "com.diffplug.durian:durian-core:1.2.0",  # depends on animal-sniffer-annotations and j2objc-annotations
+    ],
+    excluded_artifacts = [
+        "com.google.j2objc:j2objc-annotations",
+        "org.codehaus.mojo:animal-sniffer-annotations",
+    ],
+)
+dev_maven.install(
+    name = "java_export_exclusion_testing",
+    artifacts = [
+        "com.google.protobuf:protobuf-java:3.23.1",
+    ],
+    lock_file = "//tests/custom_maven_install:java_export_exclusion_testing_install.json",
+)
+
+# https://github.com/bazelbuild/rules_jvm_external/issues/351
+dev_maven.install(
+    name = "json_artifacts_testing",
+    artifacts = [
+        "org.json:json:20190722",
+        "io.quarkus:quarkus-maven-plugin:1.0.1.Final",
+        "io.quarkus:quarkus-bom-descriptor-json:1.0.1.Final",
+    ],
+    fetch_sources = True,
+    lock_file = "//tests/custom_maven_install:json_artifacts_testing_install.json",
+    repositories = [
+        "https://repo.maven.apache.org/maven2/",
+        "https://repo.spring.io/plugins-release/",
+    ],
+)
+
+[dev_maven.artifact(
+    name = "service_indexing_testing",
+    testonly = True,  # must be propagated to the generated plugin
+    artifact = artifact,
+    group = "org.openjdk.jmh",
+    version = "1.37",
+) for artifact in ("jmh-core", "jmh-generator-annprocess")]
+
+dev_maven.install(
+    name = "service_indexing_testing",
+    artifacts = [
+        "com.google.auto.value:auto-value:1.10.4",
+        "com.google.auto.value:auto-value-annotations:1.10.4",
+        "org.projectlombok:lombok:1.18.22",
+    ],
+    lock_file = "//tests/custom_maven_install:service_indexing_testing.json",
+)
+dev_maven.install(
+    name = "jvm_import_test",
+    artifacts = [
+        "com.google.code.findbugs:jsr305:3.0.2",
+    ],
+)
+dev_maven.install(
+    name = "m2local_testing",
+    artifacts = [
+        # this is a test jar built for integration
+        # tests in this repo
+        "com.example:kt:1.0.0",
+    ],
+    fail_on_missing_checksum = True,
+    repositories = [
+        "m2Local",
+        "https://repo1.maven.org/maven2",
+    ],
+)
+dev_maven.install(
+    name = "m2local_testing_ignore_empty_files",
+    artifacts = [
+        # this is a test jar built for integration
+        # tests in this repo
+        "com.example:kt:1.0.0",
+    ],
+    fetch_sources = True,
+    ignore_empty_files = True,
+    repositories = [
+        "m2Local",
+        "https://repo1.maven.org/maven2",
+    ],
+)
+dev_maven.install(
+    name = "m2local_testing_ignore_empty_files_repin",
+    artifacts = [
+        # this is a test jar built for integration
+        # tests in this repo
+        "com.example:kt:1.0.0",
+    ],
+    fetch_sources = True,
+    ignore_empty_files = True,
+    lock_file = "//tests/custom_maven_install:m2local_testing_ignore_empty_files_with_pinned_file_install.json",
+    repositories = [
+        "m2Local",
+        "https://repo1.maven.org/maven2",
+    ],
+)
+dev_maven.install(
+    name = "m2local_testing_repin",
+    artifacts = [
+        # this is a test jar built for integration
+        # tests in this repo
+        "com.example:no-docs:1.0.0",
+    ],
+    lock_file = "//tests/custom_maven_install:m2local_testing_with_pinned_file_install.json",
+    repositories = [
+        "m2Local",
+        "https://repo1.maven.org/maven2",
+    ],
+)
+dev_maven.install(
+    name = "m2local_testing_without_checksum",
+    artifacts = [
+        # this is a test jar built for integration
+        # tests in this repo
+        "com.example:kt:1.0.0",
+    ],
+    # jar won't have checksums for this test case
+    fail_on_missing_checksum = False,
+    repositories = [
+        "m2Local",
+        "https://repo1.maven.org/maven2",
+    ],
+)
+dev_maven.install(
+    name = "artifact_with_plus",
+    artifacts = [
+        "ch.epfl.scala:compiler-interface:1.3.0-M4+47-d881fa2f",
+    ],
+    repositories = [
+        "https://repo1.maven.org/maven2",
+    ],
+)
+dev_maven.install(
+    name = "artifact_with_plus_repin",
+    artifacts = [
+        "ch.epfl.scala:compiler-interface:1.3.0-M4+47-d881fa2f",
+    ],
+    lock_file = "//tests/custom_maven_install:artifact_with_plus_repin_install.json",
+    repositories = [
+        "https://repo1.maven.org/maven2",
+    ],
+)
+dev_maven.install(
+    name = "manifest_stamp_testing",
+    artifacts = [
+        "com.google.guava:guava:27.0-jre",
+        "javax.inject:javax.inject:1",
+        "org.apache.beam:beam-sdks-java-core:2.15.0",
+        "org.bouncycastle:bcprov-jdk15on:1.64",
+    ],
+    lock_file = "//tests/custom_maven_install:manifest_stamp_testing_install.json",
+)
+dev_maven.install(
+    name = "maven_install_in_custom_location",
+    artifacts = ["com.google.guava:guava:27.0-jre"],
+    lock_file = "//tests/custom_maven_install:maven_install.json",
+)
+dev_maven.install(
+    # This name matches the one in `tests/integration/bzlmod_lock_files`
+    name = "multiple_lock_files",
+    artifacts = ["org.zeromq:jeromq:0.5.4"],
+    lock_file = "//tests/custom_maven_install:multiple_lock_files_install.json",
+)
+dev_maven.install(
+    name = "maven_resolved_with_boms",
+    # Before adding a dependency here, add a reduced test case to `ResolverTestBase`
+    # so that we have a clearer understanding of _why_ this dependency is here, and
+    # what we did to fix the problem.
+    artifacts = [
+        # A transitive dependency pulls in a `managedDependencies` section which sets the
+        # `xmlpull` version to 1.2.0, which hasn't been publicly released. Maven and Gradle
+        # both handle this situation gracefully and correctly resolve to `xmlpull` 1.1.3.1
+        "org.drools:drools-mvel:7.53.0.Final",
+        "org.optaplanner:optaplanner-core:7.53.0.Final",
+        "org.seleniumhq.selenium:selenium-java",
+    ],
+    boms = [
+        "org.seleniumhq.selenium:selenium-bom:4.14.1",
+    ],
+    fail_if_repin_required = True,
+    lock_file = "@rules_jvm_external//tests/custom_maven_install:maven_resolved_install.json",
+    repositories = [
+        "https://repo.spring.io/plugins-release/",  # Requires auth, but we don't have it
+        "https://repo1.maven.org/maven2",
+    ],
+    resolver = "maven",
+)
+dev_maven.artifact(
+    name = "maven_resolved_with_boms",
+    testonly = True,
+    artifact = "auto-value-annotations",
+    exclusions = [
+        "org.slf4j:slf4j-api",
+    ],
+    group = "com.google.auto.value",
+    version = "1.6.3",
+)
+dev_maven.artifact(
+    name = "maven_resolved_with_boms",
+    artifact = "json-lib",
+    classifier = "jdk15",
+    group = "net.sf.json-lib",
+    version = "2.4",
+)
+dev_maven.install(
+    name = "override_target_in_deps",
+    artifacts = [
+        "io.opentelemetry:opentelemetry-sdk:1.28.0",
+        "redis.clients:jedis:5.0.2",
+    ],
+    lock_file = "@rules_jvm_external//tests/custom_maven_install:override_target_in_deps_install.json",
+)
+dev_maven.override(
+    name = "override_target_in_deps",
+    coordinates = "io.opentelemetry:opentelemetry-api",
+    target = "@//tests/integration/override_targets:additional_deps",
+)
+dev_maven.install(
+    name = "policy_pinned_testing",
+    artifacts = [
+        # https://github.com/bazelbuild/rules_jvm_external/issues/107
+        "com.google.cloud:google-cloud-storage:1.66.0",
+        "com.google.guava:guava:25.0-android",
+    ],
+    lock_file = "//tests/custom_maven_install:policy_pinned_testing_install.json",
+    version_conflict_policy = "pinned",
+)
+
+# These artifacts helped discover limitations in the Coursier resolver. Each
+# artifact listed here *must have* an accompanying issue. We build_test these
+# targets to ensure that they remain supported by the rule.
+dev_maven.install(
+    name = "regression_testing_coursier",
+    artifacts = [
+        # https://github.com/bazelbuild/rules_jvm_external/issues/74
+        "org.pantsbuild:jarjar:1.6.6",
+        # https://github.com/bazelbuild/rules_jvm_external/issues/59
+        "junit:junit:4.12",
+        "org.jetbrains.kotlin:kotlin-test:1.3.21",
+        # https://github.com/bazelbuild/rules_jvm_external/issues/101
+        # As referenced in the issue, daml is not available anymore, hence
+        # replacing with another artifact with a classifier.
+        "org.eclipse.jetty:jetty-http:jar:tests:9.4.20.v20190813",
+        # https://github.com/bazelbuild/rules_jvm_external/issues/116
+        "org.eclipse.jetty.orbit:javax.servlet:3.0.0.v201112011016",
+        # https://github.com/bazelbuild/rules_jvm_external/issues/98
+        "com.github.fommil.netlib:all:1.1.2",
+        "nz.ac.waikato.cms.weka:weka-stable:3.8.1",
+        # https://github.com/bazelbuild/rules_jvm_external/issues/111
+        "com.android.support:appcompat-v7:aar:28.0.0",
+        "com.google.android.gms:play-services-base:16.1.0",
+        # https://github.com/bazelbuild/rules_jvm_external/issues/119#issuecomment-484278260
+        "org.apache.flink:flink-test-utils_2.12:1.8.0",
+        # https://github.com/bazelbuild/rules_jvm_external/issues/170
+        "ch.epfl.scala:compiler-interface:1.3.0-M4+20-c8a2f9bd",
+        # https://github.com/bazelbuild/rules_jvm_external/issues/172
+        "org.openjfx:javafx-base:11.0.1",
+        # https://github.com/bazelbuild/rules_jvm_external/issues/178
+        "io.kubernetes:client-java:4.0.0-beta1",
+        # https://github.com/bazelbuild/rules_jvm_external/issues/199
+        "com.google.ar.sceneform.ux:sceneform-ux:1.10.0",
+        # https://github.com/bazelbuild/rules_jvm_external/issues/119#issuecomment-504704752
+        "com.github.oshi:oshi-parent:3.4.0",
+        "com.github.spinalhdl:spinalhdl-core_2.11:1.3.6",
+        "com.github.spinalhdl:spinalhdl-lib_2.11:1.3.6",
+        # https://github.com/bazelbuild/rules_jvm_external/issues/201
+        "org.apache.kafka:kafka_2.11:2.1.1",
+        "io.confluent:kafka-avro-serializer:5.0.1",
+        # https://github.com/bazelbuild/rules_jvm_external/issues/309
+        "io.quarkus.http:quarkus-http-servlet:3.0.0.Beta1",
+        # https://github.com/bazelbuild/rules_jvm_external/issues/371
+        "com.fasterxml.jackson:jackson-bom:2.9.10",
+        "org.junit:junit-bom:5.3.1",
+        # https://github.com/bazelbuild/rules_jvm_external/issues/686
+        "io.netty:netty-tcnative-boringssl-static:2.0.51.Final",
+        # https://github.com/bazelbuild/rules_jvm_external/issues/907
+        # Any two platforms to ensure that it doesn't work _only_ under the host operating system
+        "com.google.protobuf:protoc:exe:linux-x86_64:3.21.12",
+        "com.google.protobuf:protoc:exe:osx-aarch_64:3.21.12",
+        # https://github.com/bazelbuild/rules_jvm_external/issues/917
+        # androidx core-testing POM has "exclusion" for "byte-buddy" but it should be downloaded as mockito-core
+        # dependency when the usually omitted "jar" packaging type is specified.
+        "org.mockito:mockito-core:jar:3.3.3",
+        "androidx.arch.core:core-testing:aar:2.1.0",
+        # https://github.com/bazelbuild/rules_jvm_external/issues/1028
+        "build.buf:protovalidate:0.1.9",
+    ],
+    fail_if_repin_required = True,
+    generate_compat_repositories = True,
+    lock_file = "//tests/custom_maven_install:regression_testing_coursier_install.json",
+    repositories = [
+        "https://repo1.maven.org/maven2",
+        "https://maven.google.com",
+        "https://packages.confluent.io/maven/",
+    ],
+)
+dev_maven.override(
+    name = "regression_testing_coursier",
+    coordinates = "com.google.ar.sceneform:rendering",
+    target = "@//tests/integration/override_targets:sceneform_rendering",
+)
+
+# https://github.com/bazelbuild/rules_jvm_external/issues/92#issuecomment-478430167
+dev_maven.artifact(
+    name = "regression_testing_coursier",
+    artifact = "javapoet",
+    group = "com.squareup",
+    neverlink = True,
+    version = "1.11.1",
+)
+
+# https://github.com/bazelbuild/rules_jvm_external/issues/852
+dev_maven.artifact(
+    name = "regression_testing_coursier",
+    artifact = "jaxb-ri",
+    exclusions = [
+        "com.sun.xml.bind:jaxb-samples",
+        "com.sun.xml.bind:jaxb-release-documentation",
+    ],
+    group = "com.sun.xml.bind",
+    version = "2.3.6",
+)
+
+# https://github.com/bazelbuild/rules_jvm_external/issues/865
+dev_maven.artifact(
+    name = "regression_testing_coursier",
+    artifact = "google-api-services-compute",
+    classifier = "javadoc",
+    group = "com.google.apis",
+    version = "v1-rev235-1.25.0",
+)
+
+# These artifacts helped discover limitations in the Maven resolver. Each
+# artifact listed here *must have* an accompanying issue. We build_test these
+# targets to ensure that they remain supported by the rule.
+dev_maven.install(
+    name = "regression_testing_maven",
+    artifacts = [
+        # Depends on org.apache.yetus:audience-annotations:0.11.0 which has an invalid pom
+        "org.apache.parquet:parquet-common:1.11.1",
+        # https://github.com/bazelbuild/rules_jvm_external/issues/1144
+        "org.codehaus.plexus:plexus:1.0.4",
+        "org.hamcrest:hamcrest-core:1.3",
+        # https://github.com/bazelbuild/rules_jvm_external/issues/1162
+        "io.opentelemetry:opentelemetry-sdk",
+    ],
+    boms = [
+        "io.opentelemetry:opentelemetry-bom:1.31.0",
+    ],
+    fail_if_repin_required = True,
+    generate_compat_repositories = True,
+    lock_file = "//tests/custom_maven_install:regression_testing_maven_install.json",
+    repin_instructions = "Please run `REPIN=1 bazel run @regression_testing_maven//:pin` to refresh the lock file.",
+    repositories = [
+        "https://repo1.maven.org/maven2",
+        "https://maven.google.com",
+    ],
+    resolver = "maven",
+)
+
+# https://github.com/bazelbuild/rules_jvm_external/issues/1162
+dev_maven.artifact(
+    name = "regression_testing_maven",
+    artifact = "opentelemetry-api",
+    group = "io.opentelemetry",
+    neverlink = True,
+)
+dev_maven.install(
+    name = "starlark_aar_import_test",
+    # Not actually necessary since this is the default value, but useful for
+    # testing.
+    aar_import_bzl_label = "@rules_android//android:rules.bzl",
+    artifacts = [
+        "com.android.support:appcompat-v7:28.0.0",
+    ],
+    fetch_sources = False,
+    repositories = [
+        "https://repo1.maven.org/maven2",
+        "https://maven.google.com",
+    ],
+    use_starlark_android_rules = True,
+)
+dev_maven.install(
+    name = "starlark_aar_import_with_sources_test",
+    # Not actually necessary since this is the default value, but useful for
+    # testing.
+    aar_import_bzl_label = "@rules_android//android:rules.bzl",
+    artifacts = [
+        "androidx.work:work-runtime:2.6.0",
+    ],
+    fetch_sources = True,
+    repositories = [
+        "https://repo1.maven.org/maven2",
+        "https://maven.google.com",
+    ],
+    use_starlark_android_rules = True,
+)
+dev_maven.install(
+    name = "strict_visibility_testing",
+    artifacts = [
+        # https://github.com/bazelbuild/rules_jvm_external/issues/94
+        "org.apache.tomcat:tomcat-catalina:9.0.24",
+    ],
+    strict_visibility = True,
+)
+
+# https://github.com/bazelbuild/rules_jvm_external/issues/255
+dev_maven.artifact(
+    name = "strict_visibility_testing",
+    artifact = "jetty-http",
+    classifier = "tests",
+    group = "org.eclipse.jetty",
+    version = "9.4.20.v20190813",
+)
+dev_maven.install(
+    name = "strict_visibility_with_compat_testing",
+    artifacts = [
+        # Must not be in any other maven_install where generate_compat_repositories = True
+        "com.google.http-client:google-http-client-gson:1.42.3",
+    ],
+    generate_compat_repositories = True,
+    strict_visibility = True,
+)
+dev_maven.artifact(
+    name = "testonly_testing",
+    artifact = "guava",
+    group = "com.google.guava",
+    version = "27.0-jre",
+)
+dev_maven.artifact(
+    name = "testonly_testing",
+    testonly = True,
+    artifact = "auto-value-annotations",
+    group = "com.google.auto.value",
+    version = "1.6.3",
+)
+
+# https://github.com/bazelbuild/rules_jvm_external/issues/433
+dev_maven.install(
+    name = "version_interval_testing",
+    artifacts = [
+        "io.grpc:grpc-netty-shaded:1.29.0",
+    ],
+)
+dev_maven.install(
+    name = "v1_lock_file_format",
+    artifacts = [
+        # Coordinates that are in no other `maven_install`
+        "org.seleniumhq.selenium:selenium-remote-driver:4.8.0",
+    ],
+    generate_compat_repositories = True,
+    lock_file = "//tests/custom_maven_install:v1_lock_file_format_install.json",
+)
+
+# Where there are file locks, the pinned and unpinned repos are listed
+# next to each other. Where compat repositories are created, they are
+# listed next to the repo that created them. The list is otherwise kept
+# in alphabetical order. We use comments to space out the entries and to
+# prevent `buildifier` from over-zealously sorting things more than we
+# want it to
+use_repo(
+    dev_maven,
+    "duplicate_version_warning",
+    "duplicate_version_warning_same_version",
+    "exclusion_testing",
+    "forcing_versions",
+    "global_exclusion_testing",
+    "m2local_testing",
+    "m2local_testing_ignore_empty_files",
+
+    # Pinned repo
+    "m2local_testing_ignore_empty_files_repin",
+    "unpinned_m2local_testing_ignore_empty_files_repin",
+
+    # Pinned repo
+    "java_export_exclusion_testing",
+    "unpinned_java_export_exclusion_testing",
+
+    # Pinned repo
+    "json_artifacts_testing",
+    "unpinned_json_artifacts_testing",
+
+    # Pinned repo
+    "service_indexing_testing",
+    "unpinned_service_indexing_testing",
+
+    # Unpinned repo
+    "jvm_import_test",
+    "manifest_stamp_testing",
+    "unpinned_manifest_stamp_testing",
+
+    # Pinned repo
+    "artifact_with_plus",
+    "artifact_with_plus_repin",
+    "m2local_testing_repin",
+    "m2local_testing_without_checksum",
+    "unpinned_artifact_with_plus_repin",
+    "unpinned_m2local_testing_repin",
+
+    # Pinned repo
+    "maven",
+    "unpinned_maven",
+
+    # Pinned repo
+    "maven_install_in_custom_location",
+    "unpinned_maven_install_in_custom_location",
+
+    # Unpinned repo
+    "multiple_lock_files",
+
+    # Pinned repo
+    "maven_resolved_with_boms",
+
+    # Pinned repo
+    "override_target_in_deps",
+    "unpinned_override_target_in_deps",
+
+    # Pinned repo
+    "policy_pinned_testing",
+    "unpinned_policy_pinned_testing",
+
+    # Regression testing and libraries exposed as compat repos
+    "com_android_support_appcompat_v7_aar_28_0_0",
+    "com_google_guava_guava_27_0_jre",
+    "nz_ac_waikato_cms_weka_weka_stable",
+    "org_apache_flink_flink_test_utils_2_12",
+    "org_eclipse_jetty_jetty_http_tests",
+    "org_pantsbuild_jarjar",
+    "regression_testing_coursier",
+    "regression_testing_maven",
+    "unpinned_regression_testing_coursier",
+    "unpinned_regression_testing_maven",
+
+    # Back to the testing repos
+    "starlark_aar_import_test",
+    "starlark_aar_import_with_sources_test",
+    "strict_visibility_testing",
+
+    # Repo with compat repos
+    "com_google_http_client_google_http_client_gson",
+    "strict_visibility_with_compat_testing",
+
+    # Final entries
+    "com_google_http_client_google_http_client",
+    "testonly_testing",
+    "unpinned_v1_lock_file_format",
+    "v1_lock_file_format",
+    "version_interval_testing",
+)
+
+http_file(
+    name = "com.google.ar.sceneform_rendering",
+    downloaded_file_path = "rendering-1.10.0.aar",
+    sha256 = "d2f6cd1d54eee0d5557518d1edcf77a3ba37494ae94f9bb862e570ee426a3431",
+    urls = [
+        "https://dl.google.com/android/maven2/com/google/ar/sceneform/rendering/1.10.0/rendering-1.10.0.aar",
+    ],
+)
+
+http_file(
+    name = "hamcrest_core_for_test",
+    downloaded_file_path = "hamcrest-core-1.3.jar",
+    sha256 = "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
+    urls = [
+        "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
+    ],
+)
+
+http_file(
+    name = "hamcrest_core_srcs_for_test",
+    downloaded_file_path = "hamcrest-core-1.3-sources.jar",
+    sha256 = "e223d2d8fbafd66057a8848cc94222d63c3cedd652cc48eddc0ab5c39c0f84df",
+    urls = [
+        "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3-sources.jar",
+    ],
+)
+
+http_file(
+    name = "gson_for_test",
+    downloaded_file_path = "gson-2.9.0.jar",
+    sha256 = "c96d60551331a196dac54b745aa642cd078ef89b6f267146b705f2c2cbef052d",
+    urls = [
+        "https://repo1.maven.org/maven2/com/google/code/gson/gson/2.9.0/gson-2.9.0.jar",
+    ],
+)
+
+http_file(
+    name = "junit_platform_commons_for_test",
+    downloaded_file_path = "junit-platform-commons-1.8.2.jar",
+    sha256 = "d2e015fca7130e79af2f4608dc54415e4b10b592d77333decb4b1a274c185050",
+    urls = [
+        "https://repo1.maven.org/maven2/org/junit/platform/junit-platform-commons/1.8.2/junit-platform-commons-1.8.2.jar",
+    ],
+)
+
+# https://github.com/bazelbuild/rules_jvm_external/issues/865
+http_file(
+    name = "google_api_services_compute_javadoc_for_test",
+    downloaded_file_path = "google-api-services-compute-v1-rev235-1.25.0-javadoc.jar",
+    sha256 = "b03be5ee8effba3bfbaae53891a9c01d70e2e3bd82ad8889d78e641b22bd76c2",
+    urls = [
+        "https://repo1.maven.org/maven2/com/google/apis/google-api-services-compute/v1-rev235-1.25.0/google-api-services-compute-v1-rev235-1.25.0-javadoc.jar",
+    ],
+)
+
+http_file(
+    name = "lombok_for_test",
+    downloaded_file_path = "lombok-1.18.22.jar",
+    sha256 = "ecef1581411d7a82cc04281667ee0bac5d7c0a5aae74cfc38430396c91c31831",
+    urls = [
+        "https://repo1.maven.org/maven2/org/projectlombok/lombok/1.18.22/lombok-1.18.22.jar",
+    ],
+)

--- a/modules/rules_jvm_external/6.2.bzlmod.1/patches/maven_install.patch
+++ b/modules/rules_jvm_external/6.2.bzlmod.1/patches/maven_install.patch
@@ -1,0 +1,17 @@
+diff --git a/private/extensions/maven.bzl b/private/extensions/maven.bzl
+index 0720d37..3c21d13 100644
+--- a/private/extensions/maven.bzl
++++ b/private/extensions/maven.bzl
+@@ -433,12 +433,6 @@ def _maven_impl(mctx):
+                 ignore_empty_files = repo.get("ignore_empty_files"),
+                 additional_coursier_options = repo.get("additional_coursier_options"),
+             )
+-        else:
+-            # Only the coursier resolver allows the lock file to be omitted.
+-            unpinned_maven_pin_command_alias(
+-                name = "unpinned_" + name,
+-                alias = "@%s//:pin" % name,
+-            )
+ 
+         if repo.get("generate_compat_repositories") and not repo.get("lock_file"):
+             seen = _generate_compat_repos(name, compat_repos, artifacts)

--- a/modules/rules_jvm_external/6.2.bzlmod.1/patches/module_dot_bazel.patch
+++ b/modules/rules_jvm_external/6.2.bzlmod.1/patches/module_dot_bazel.patch
@@ -1,0 +1,10 @@
+--- a/MODULE.bazel
++++ a/MODULE.bazel
+@@ -1,6 +1,6 @@
+ module(
+     name = "rules_jvm_external",
+-    version = "6.2",
++    version = "6.2.bzlmod.1",
+     bazel_compatibility = [">=7.0.0"],
+ )
+ 

--- a/modules/rules_jvm_external/6.2.bzlmod.1/source.json
+++ b/modules/rules_jvm_external/6.2.bzlmod.1/source.json
@@ -1,0 +1,10 @@
+{
+    "url": "https://github.com/bazelbuild/rules_jvm_external/releases/download/6.2/rules_jvm_external-6.2.tar.gz",
+    "integrity": "sha256-gIy1wwtfcNEqKnRaKe3EZyj9NfoZXBdipZa2OunOvgU=",
+    "strip_prefix": "rules_jvm_external-6.2",
+    "patches": {
+        "maven_install.patch": "sha256-io2iGFrgwR6Igu3JS7v3lftj7wBc26Y90QU+burv354=",
+        "module_dot_bazel.patch": "sha256-KVxtDkX7Y1nlynQVc7o7x1hryTr8Jx462NaGMk9gImU="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_jvm_external/metadata.json
+++ b/modules/rules_jvm_external/metadata.json
@@ -1,0 +1,11 @@
+{
+    "homepage": "https://github.com/bazelbuild/rules_jvm_external",
+    "maintainers": [],
+    "repository": [
+        "github:bazelbuild/rules_jvm_external"
+    ],
+    "versions": [
+        "6.2.bzlmod.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
This is a patched version of 6.2 to work around bazelbuild/rules_jvm_external#1205