### PR TITLE
build: Add cross-media-measurement-api@0.68.0

### DIFF
--- a/modules/cross-media-measurement-api/0.68.0/MODULE.bazel
+++ b/modules/cross-media-measurement-api/0.68.0/MODULE.bazel
@@ -1,0 +1,26 @@
+module(
+    name = "cross-media-measurement-api",
+    version = "0.68.0",
+    repo_name = "wfa_measurement_proto",
+)
+
+# Bazel Central Registry deps.
+bazel_dep(
+    name = "rules_proto",
+    version = "5.3.0-21.7",
+)
+bazel_dep(
+    name = "protobuf",
+    version = "21.7",
+    repo_name = "com_google_protobuf",
+)
+
+# WFA registry deps.
+bazel_dep(
+    name = "googleapis",
+    version = "0.0.0-bzlmod.1",
+    repo_name = "com_google_googleapis",
+)
+
+non_module_deps = use_extension("//build:non_module_deps.bzl", "non_module_deps")
+use_repo(non_module_deps, "plantuml")

--- a/modules/cross-media-measurement-api/0.68.0/patches/module_dot_bazel.patch
+++ b/modules/cross-media-measurement-api/0.68.0/patches/module_dot_bazel.patch
@@ -1,0 +1,9 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -1,5 +1,6 @@
+ module(
+     name = "cross-media-measurement-api",
++    version = "0.68.0",
+     repo_name = "wfa_measurement_proto",
+ )
+ 

--- a/modules/cross-media-measurement-api/0.68.0/source.json
+++ b/modules/cross-media-measurement-api/0.68.0/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/world-federation-of-advertisers/cross-media-measurement-api/archive/refs/tags/v0.68.0.tar.gz",
+    "integrity": "sha256-ystPMs7XKeg7BiVXKdZgWI7JmIUsDNBhiDM87WLHT6w=",
+    "strip_prefix": "cross-media-measurement-api-0.68.0",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-R3YLWrVhI8AdKsWDIm2gHSMjtUw00B/aARGhio65mW8="
+    }
+}


### PR DESCRIPTION
add_module log:

```
lindreamdeyi@lindreamdeyi:~/IdeaProjects/bazel-central-registry$ bazel run //tools:add_module
Starting local Bazel server and connecting to it...
INFO: Analyzed target //tools:add_module (109 packages loaded, 3445 targets configured).
INFO: Found 1 target...
Target //tools:add_module up-to-date:
  bazel-bin/tools/add_module
INFO: Elapsed time: 4.363s, Critical Path: 0.09s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/tools/add_module
INFO: Getting module information from user input...
ACTION: Please enter the module name: cross-media-measurement-api
ACTION: Please enter the module version: 0.68.0
ACTION: Please enter the compatibility level [default is 0]: 
ACTION: Please enter the URL of the source archive: https://github.com/world-federation-of-advertisers/cross-media-measurement-api/archive/refs/tags/v0.68.0.tar.gz
ACTION: Please enter the strip_prefix value of the archive [default None]: cross-media-measurement-api-0.68.0            
ACTION: Do you want to add patch files? [y/N]: N
ACTION: Do you want to add a BUILD file? [y/N]: N
ACTION: Do you want to specify a MODULE.bazel file? [y/N]: y
ACTION: Please enter the MODULE.bazel file path: modulebazel/MODULE.bazel
ACTION: Do you want to specify an existing presubmit.yml file? (See https://github.com/bazelbuild/bazel-central-registry/tree/main/docs#presubmit) [y/N]: N
ACTION: Please enter a list of build targets you want to expose to downstream users, separated by `,`: none
ACTION: Do you have a test module in your source archive? [Y/n]: n
INFO: Saving module information to cross-media-measurement-api.20240926-193601.json
INFO: You can use it via --input=cross-media-measurement-api.20240926-193601.json
INFO: cross-media-measurement-api 0.68.0 is added into the registry.
INFO: Running ./tools/bcr_validation.py --check=cross-media-measurement-api@0.68.0 --fix


+++ Module versions to be validated:


cross-media-measurement-api@0.68.0


+++ Validating cross-media-measurement-api@0.68.0


BcrValidationResult.GOOD: No module name conflict found.

BcrValidationResult.GOOD: The module exists and is recorded in metadata.json.

BcrValidationResult.GOOD: The source URL matches one of the source repositories.

BcrValidationResult.FAILED: cross-media-measurement-api@0.68.0 is using an unstable source url: `https://github.com/world-federation-of-advertisers/cross-media-measurement-api/archive/refs/tags/v0.68.0.tar.gz`.
You should use a release archive URL in the format of `https://github.com/<ORGANIZATION>/<REPO>/releases/download/<version>/<name>.tar.gz` to ensure the archive checksum stability.
See https://blog.bazel.build/2023/02/15/github-archive-checksum.html for more context.

BcrValidationResult.GOOD: The source archive's integrity value matches.

BcrValidationResult.GOOD: The presubmit.yml file matches the previous version.

BcrValidationResult.GOOD: The presubmit.yml file is valid.

BcrValidationResult.FAILED: Checked in MODULE.bazel file doesn't match the one in the extracted and patched sources.
Please fix the MODULE.bazel file or you can add the following patch to cross-media-measurement-api@0.68.0:
    --- MODULE.bazel
    +++ MODULE.bazel
    @@ -1,5 +1,6 @@
     module(
         name = "cross-media-measurement-api",
    +    version = "0.68.0",
         repo_name = "wfa_measurement_proto",
     )
```
     
build cross-media-measurement
```
bazel build --registry="file://$HOME/IdeaProjects/bazel-registry" //...

INFO: Found 3119 targets...
INFO: Elapsed time: 157.100s, Critical Path: 134.79s
INFO: 4302 processes: 111 internal, 3309 linux-sandbox, 18 local, 864 worker.
INFO: Build completed successfully, 4302 total actions
```