### PR TITLE
build: Add grpc_ecosystem_grpc_gateway@2.26.0.bzlmod.1

### DIFF
--- a/modules/grpc_ecosystem_grpc_gateway/2.26.0.bzlmod.1/MODULE.bazel
+++ b/modules/grpc_ecosystem_grpc_gateway/2.26.0.bzlmod.1/MODULE.bazel
@@ -1,0 +1,71 @@
+module(
+    name = "grpc_ecosystem_grpc_gateway",
+    version = "2.26.0.bzlmod.1",
+)
+
+bazel_dep(name = "bazel_features", version = "1.23.0")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "rules_python", version = "1.1.0")
+bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "rules_go", version = "0.52.0", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "gazelle", version = "0.41.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "protobuf", version = "29.3", repo_name = "com_google_protobuf")
+bazel_dep(name = "googleapis", version = "0.0.0-20250120-318818b.bzlmod.1")
+
+# This is required as a transitive dependency and not directly needed by this module.
+# We have this version pinned to solve for differences in the MODULE.bazel.lock file
+# when running CI.
+bazel_dep(name = "rules_rust", version = "0.56.0")
+
+go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(version = "1.22.7")
+
+go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = ":go.mod")
+
+# These dependencies are required by `.proto` files but are not captured in `go.mod`,
+# so they have to explicitly be made known to Gazelle.
+go_deps.module(
+    path = "google.golang.org/grpc/cmd/protoc-gen-go-grpc",
+    sum = "h1:rNBFJjBCOgVr9pWD7rs/knKL4FRTKgpZmsRfV214zcA=",
+    version = "v1.3.0",
+)
+go_deps.module(
+    path = "github.com/golang/protobuf",
+    sum = "h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=",
+    version = "v1.5.4",
+)
+go_deps.module(
+    path = "github.com/bazelbuild/buildtools/v7",
+    sum = "h1:BRlRwQ/4rd608QvjsM9HSzBLLM1nXyzHaDzdkBAyDKk=",
+    version = "v7.3.1",
+)
+go_deps.module(
+    path = "golang.org/x/tools",
+    sum = "h1:vU5i/LfpvrRCpgM/VPfJLg5KjxD3E+hfT1SH+d9zLwg=",
+    version = "v0.21.1-0.20240508182429-e35e4ccd0d2d",
+)
+use_repo(
+    go_deps,
+    "com_github_antihax_optional",
+    "com_github_bazelbuild_buildtools_v7",
+    "com_github_golang_protobuf",
+    "com_github_google_go_cmp",
+    "com_github_rogpeppe_fastuuid",
+    "in_gopkg_yaml_v3",
+    "org_golang_google_genproto_googleapis_api",
+    "org_golang_google_genproto_googleapis_rpc",
+    "org_golang_google_grpc",
+    "org_golang_google_grpc_cmd_protoc_gen_go_grpc",
+    "org_golang_google_protobuf",
+    "org_golang_x_oauth2",
+    "org_golang_x_text",
+    "org_golang_x_tools",
+)
+
+non_module_deps = use_extension(":non_module_deps.bzl", "non_module_deps")
+use_repo(
+    non_module_deps,
+    "com_github_bazelbuild_buildtools",
+)

--- a/modules/grpc_ecosystem_grpc_gateway/2.26.0.bzlmod.1/patches/wfa_module.patch
+++ b/modules/grpc_ecosystem_grpc_gateway/2.26.0.bzlmod.1/patches/wfa_module.patch
@@ -1,0 +1,37 @@
+diff --git a/.bazelrc b/.bazelrc
+index f43622ed..afd428dc 100644
+--- a/.bazelrc
++++ b/.bazelrc
+@@ -1,2 +1,6 @@
+ build --cxxopt=-std=c++14 --host_cxxopt=-std=c++14
+ build --test_output=errors
++
++# Use WFA Bazel registry.
++common --registry=https://raw.githubusercontent.com/world-federation-of-advertisers/bazel-registry/main
++common --registry=https://bcr.bazel.build
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 7a51defc..7bc56809 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,11 +1,8 @@
+ module(
+     name = "grpc_ecosystem_grpc_gateway",
+-    # TODO: Change this to the actual version on each release.
+-    #       This can wait until we publish this project on the Bazel registry.
+-    version = "0.0.0",
++    version = "2.26.0.bzlmod.1",
+ )
+ 
+-# Bazel Central Registry modules.
+ bazel_dep(name = "bazel_features", version = "1.23.0")
+ bazel_dep(name = "rules_license", version = "1.0.0")
+ bazel_dep(name = "rules_python", version = "1.1.0")
+@@ -14,7 +11,7 @@ bazel_dep(name = "rules_go", version = "0.52.0", repo_name = "io_bazel_rules_go"
+ bazel_dep(name = "gazelle", version = "0.41.0", repo_name = "bazel_gazelle")
+ bazel_dep(name = "bazel_skylib", version = "1.7.1")
+ bazel_dep(name = "protobuf", version = "29.3", repo_name = "com_google_protobuf")
+-bazel_dep(name = "googleapis", version = "0.0.0-20240819-fe8ba054a")
++bazel_dep(name = "googleapis", version = "0.0.0-20250120-318818b.bzlmod.1")
+ 
+ # This is required as a transitive dependency and not directly needed by this module.
+ # We have this version pinned to solve for differences in the MODULE.bazel.lock file

--- a/modules/grpc_ecosystem_grpc_gateway/2.26.0.bzlmod.1/source.json
+++ b/modules/grpc_ecosystem_grpc_gateway/2.26.0.bzlmod.1/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/grpc-ecosystem/grpc-gateway/archive/refs/tags/v2.26.0.tar.gz",
+    "integrity": "sha256-5cQ5GKRTtt/xHnG47ZgTkHJPOfoUA65W0vDlzBYGEx4=",
+    "strip_prefix": "grpc-gateway-2.26.0",
+    "patches": {
+        "wfa_module.patch": "sha256-5tDVdC7oYeorPlll/Yc3Qvweto7oOI+kHUHXpG0bKgg="
+    },
+    "patch_strip": 1
+}

--- a/modules/grpc_ecosystem_grpc_gateway/metadata.json
+++ b/modules/grpc_ecosystem_grpc_gateway/metadata.json
@@ -5,7 +5,8 @@
         "github:grpc-ecosystem/grpc-gateway"
     ],
     "versions": [
-        "2.25.1"
+        "2.25.1",
+        "2.26.0.bzlmod.1"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
This uses googleapis from the WFA registry instead of BCR.