### PR TITLE
build: Add rules_kotlin_jvm@0.13.0

### DIFF
--- a/modules/rules_kotlin_jvm/0.13.0/MODULE.bazel
+++ b/modules/rules_kotlin_jvm/0.13.0/MODULE.bazel
@@ -1,0 +1,99 @@
+module(
+    name = "rules_kotlin_jvm",
+    version = "0.13.0",
+    repo_name = "wfa_rules_kotlin_jvm",
+)
+
+KOTLIN_RELEASE_VERSION = "2.2.21"  # Compatible with rules_kotlin version.
+
+KOTLINX_COROUTINES_VERSION = "1.11.0"
+
+GRPC_JAVA_VERSION = "1.77.0"
+
+GRPC_KOTLIN_VERSION = "1.5.0"
+
+PROTOBUF_JAVA_VERSION = "4.33.1"  # Compatible with protobuf version.
+
+bazel_dep(
+    name = "bazel_skylib",
+    version = "1.8.1",
+)
+bazel_dep(
+    name = "rules_java",
+    version = "8.15.2",
+)
+bazel_dep(
+    name = "rules_kotlin",
+    version = "2.2.2",
+)
+bazel_dep(
+    name = "rules_jvm_external",
+    version = "6.8",
+)
+bazel_dep(
+    name = "protobuf",
+    version = "33.1",
+    repo_name = "com_google_protobuf",
+)
+
+maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+maven.artifact(
+    artifact = "protoc-gen-grpc-kotlin",
+    classifier = "jdk8",
+    group = "io.grpc",
+    version = GRPC_KOTLIN_VERSION,
+)
+maven.artifact(
+    testonly = True,
+    artifact = "kotlin-test",
+    group = "org.jetbrains.kotlin",
+)
+maven.install(
+    artifacts = [
+        "org.jetbrains.kotlin:kotlin-stdlib",
+        "org.jetbrains.kotlin:kotlin-reflect",
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core",
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm",
+        "io.grpc:grpc-api",
+        "io.grpc:grpc-protobuf",
+        "io.grpc:grpc-stub",
+        "io.grpc:grpc-kotlin-stub:" + GRPC_KOTLIN_VERSION,
+        # TODO(bazelbuild/bazel-worker-api/issues#14): Remove versions when fixed.
+        "com.google.protobuf:protobuf-java:" + PROTOBUF_JAVA_VERSION,
+        "com.google.protobuf:protobuf-java-util:" + PROTOBUF_JAVA_VERSION,
+        "com.google.protobuf:protobuf-kotlin:" + PROTOBUF_JAVA_VERSION,
+    ],
+    boms = [
+        "org.jetbrains.kotlin:kotlin-bom:" + KOTLIN_RELEASE_VERSION,
+        "org.jetbrains.kotlinx:kotlinx-coroutines-bom:" + KOTLINX_COROUTINES_VERSION,
+        "com.google.protobuf:protobuf-bom:" + PROTOBUF_JAVA_VERSION,
+        "io.grpc:grpc-bom:" + GRPC_JAVA_VERSION,
+    ],
+    exclusions = [
+        # protobuf-java and protobuf-javalite cannot coexist.
+        "com.google.protobuf:protobuf-javalite",
+    ],
+    fail_if_repin_required = True,
+    fetch_sources = True,  # For IDE integration.
+    known_contributing_modules = [
+        "bazel_worker_java",
+        "rules_kotlin_jvm",
+    ],
+    lock_file = "//:maven_install.json",
+    resolver = "maven",
+    strict_visibility = True,
+)
+use_repo(maven, "maven")
+
+http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+http_file(
+    name = "protoc_gen_grpc_java",
+    executable = True,
+    sha256 = "6fe1f72e59f197409beff4cda25c9acbf9e82ab7b1cfb20c185bc2e61956c28e",
+    url = "https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/{version}/protoc-gen-grpc-java-{version}-linux-x86_64.exe".format(
+        version = GRPC_JAVA_VERSION,
+    ),
+)
+
+register_toolchains("//kotlin:kotlin_toolchain")

--- a/modules/rules_kotlin_jvm/0.13.0/patches/module_dot_bazel.patch
+++ b/modules/rules_kotlin_jvm/0.13.0/patches/module_dot_bazel.patch
@@ -1,0 +1,9 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -1,5 +1,6 @@
+ module(
+     name = "rules_kotlin_jvm",
++    version = "0.13.0",
+     repo_name = "wfa_rules_kotlin_jvm",
+ )
+ 

--- a/modules/rules_kotlin_jvm/0.13.0/source.json
+++ b/modules/rules_kotlin_jvm/0.13.0/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/world-federation-of-advertisers/rules_kotlin_jvm/archive/refs/tags/v0.13.0.tar.gz",
+    "integrity": "sha256-9XKKDesZwkvA4WxYOZgW3Xmq6xWpU/NIAc2X1RQvHVw=",
+    "strip_prefix": "rules_kotlin_jvm-0.13.0",
+    "patch_strip": 0,
+    "patches": {
+        "module_dot_bazel.patch": "sha256-phJ4iynd8IKgquN1AmEfpRi+d/BpzMwG+Gv/bs314Fo="
+    }
+}

--- a/modules/rules_kotlin_jvm/metadata.json
+++ b/modules/rules_kotlin_jvm/metadata.json
@@ -1,7 +1,7 @@
 {
-    "homepage": "https://github.com/SanjayVas/rules_kotlin_jvm",
+    "homepage": "https://github.com/world-federation-of-advertisers/rules_kotlin_jvm",
     "repository": [
-        "github:SanjayVas/rules_kotlin_jvm"
+        "github:world-federation-of-advertisers/rules_kotlin_jvm"
     ],
     "versions": [
         "0.1.0-rc1",
@@ -18,7 +18,8 @@
         "0.9.0",
         "0.10.0",
         "0.11.0",
-        "0.12.0"
+        "0.12.0",
+        "0.13.0"
     ],
     "yanked_versions": {
         "0.1.0-rc1": "gRPC rules are broken"


### PR DESCRIPTION
Add rules_kotlin_jvm 0.13.0 to the WFA Bazel registry. Notable changes from 0.12.0: Kotlin 2.2.21, kotlinx-coroutines 1.11.0, rules_kotlin 2.2.2. Tested locally by cloning cross-media-measurement and building with bazel build //src/main/kotlin/org/wfanet/measurement/kingdom/... --registry=file:///home/.../bazel-registry --registry=https://bcr.bazel.build (187 targets, build succeeded after repin). Also verified //src/main/kotlin/org/wfanet/measurement/reporting/... (181 targets).